### PR TITLE
Error handling in send_request method

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,12 @@
 History
 =======
 
+0.1.10 (2019-02-28)
+-------------------
+
+* Modified method "send_request". It does not throw anymore error if 's-f-1-30_error-message' is returned.
+* Updated Pipfile.lock.
+
 0.1.9 (2019-02-20)
 ------------------
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -271,36 +271,36 @@
         },
         "markupsafe": {
             "hashes": [
-                "sha256:efdc45ef1afc238db84cb4963aa689c0408912a0239b0721cb172b4016eb31d6",
-                "sha256:52ccb45e77a1085ec5461cde794e1aa037df79f473cbc69b974e73940655c8d7",
-                "sha256:525396ee324ee2da82919f2ee9c9e73b012f23e7640131dd1b53a90206a0f09c",
-                "sha256:5c3fbebd7de20ce93103cb3183b47671f2885307df4a17a0ad56a1dd51273d36",
-                "sha256:f82e347a72f955b7017a39708a3667f106e6ad4d10b25f237396a7115d8ed5fd",
-                "sha256:31cbb1359e8c25f9f48e156e59e2eaad51cd5242c05ed18a8de6dbe85184e4b7",
-                "sha256:edce2ea7f3dfc981c4ddc97add8a61381d9642dc3273737e756517cc03e84dd6",
-                "sha256:19f637c2ac5ae9da8bfd98cef74d64b7e1bb8a63038a3505cd182c3fac5eb4d9",
-                "sha256:98e439297f78fca3a6169fd330fbe88d78b3bb72f967ad9961bcac0d7fdd1550",
-                "sha256:fb7c206e01ad85ce57feeaaa0bf784b97fa3cad0d4a5737bc5295785f5c613a1",
-                "sha256:1fa6058938190ebe8290e5cae6c351e14e7bb44505c4a7624555ce57fbbeba0d",
-                "sha256:e982fe07ede9fada6ff6705af70514a52beb1b2c3d25d4e873e82114cf3c5401",
-                "sha256:5e5851969aea17660e55f6a3be00037a25b96a9b44d2083651812c99d53b14d1",
-                "sha256:f137c02498f8b935892d5c0172560d7ab54bc45039de8805075e19079c639a9c",
-                "sha256:3e835d8841ae7863f64e40e19477f7eb398674da6a47f09871673742531e6f4b",
-                "sha256:5edfa27b2d3eefa2210fb2f5d539fbed81722b49f083b2c6566455eb7422fd7e",
-                "sha256:857eebb2c1dc60e4219ec8e98dfa19553dae33608237e107db9c6078b1167856",
-                "sha256:bf54103892a83c64db58125b3f2a43df6d2cb2d28889f14c78519394feb41492",
-                "sha256:048ef924c1623740e70204aa7143ec592504045ae4429b59c30054cb31e3c432",
-                "sha256:83381342bfc22b3c8c06f2dd93a505413888694302de25add756254beee8449c",
-                "sha256:130f844e7f5bdd8e9f3f42e7102ef1d49b2e6fdf0d7526df3f87281a532d8c8b",
-                "sha256:52b07fbc32032c21ad4ab060fec137b76eb804c4b9a1c7c7dc562549306afad2",
-                "sha256:1f19ef5d3908110e1e891deefb5586aae1b49a7440db952454b4e281b41620cd",
-                "sha256:1b8a7a87ad1b92bd887568ce54b23565f3fd7018c4180136e1cf412b405a47af",
-                "sha256:d9ac82be533394d341b41d78aca7ed0e0f4ba5a2231602e2f05aa87f25c51672",
-                "sha256:1c25694ca680b6919de53a4bb3bdd0602beafc63ff001fea2f2fc16ec3a11834",
-                "sha256:7d263e5770efddf465a9e31b78362d84d015cc894ca2c131901a4445eaa61ee1",
-                "sha256:4e97332c9ce444b0c2c38dd22ddc61c743eb208d916e4265a2a3b575bdccb1d3"
+                "sha256:09027a7803a62ca78792ad89403b1b7a73a01c8cb65909cd876f7fcebd79b161",
+                "sha256:e249096428b3ae81b08327a63a485ad0878de3fb939049038579ac0ef61e17e7",
+                "sha256:500d4957e52ddc3351cabf489e79c91c17f6e0899158447047588650b5e69183",
+                "sha256:cd5df75523866410809ca100dc9681e301e3c27567cf498077e8551b6d20e42f",
+                "sha256:43a55c2930bbc139570ac2452adf3d70cdbb3cfe5912c71cdce1c2c6bbd9c5d1",
+                "sha256:b2051432115498d3562c084a49bba65d97cf251f5a331c64a12ee7e04dacc51b",
+                "sha256:98c7086708b163d425c67c7a91bad6e466bb99d797aa64f965e9d25c12111a5e",
+                "sha256:1027c282dad077d0bae18be6794e6b6b8c91d58ed8a8d89a89d59693b9131db5",
+                "sha256:62fe6c95e3ec8a7fad637b7f3d372c15ec1caa01ab47926cfdf7a75b40e0eac1",
+                "sha256:88e5fcfb52ee7b911e8bb6d6aa2fd21fbecc674eadd44118a9cc3863f938e735",
+                "sha256:ade5e387d2ad0d7ebf59146cc00c8044acbd863725f887353a10df825fc8ae21",
+                "sha256:09c4b7f37d6c648cb13f9230d847adf22f8171b1ccc4d5682398e77f40309235",
+                "sha256:79855e1c5b8da654cf486b830bd42c06e8780cea587384cf6545b7d9ac013a0b",
+                "sha256:c8716a48d94b06bb3b2524c2b77e055fb313aeb4ea620c8dd03a105574ba704f",
+                "sha256:7c1699dfe0cf8ff607dbdcc1e9b9af1755371f92a68f706051cc8c37d447c905",
+                "sha256:6dd73240d2af64df90aa7c4e7481e23825ea70af4b4922f8ede5b9e35f78a3b1",
+                "sha256:9add70b36c5666a2ed02b43b335fe19002ee5235efd4b8a89bfcf9005bebac0d",
+                "sha256:24982cc2533820871eba85ba648cd53d8623687ff11cbb805be4ff7b4c971aff",
+                "sha256:00bc623926325b26bb9605ae9eae8a215691f33cae5df11ca5424f06f2d1f473",
+                "sha256:717ba8fe3ae9cc0006d7c451f0bb265ee07739daf76355d06366154ee68d221e",
+                "sha256:535f6fc4d397c1563d08b88e485c3496cf5784e927af890fb3c3aac7f933ec66",
+                "sha256:b1282f8c00509d99fef04d8ba936b156d419be841854fe901d8ae224c59f0be5",
+                "sha256:8defac2f2ccd6805ebf65f5eeb132adcf2ab57aa11fdf4c0dd5169a004710e7d",
+                "sha256:46c99d2de99945ec5cb54f23c8cd5689f6d7177305ebff350a58ce5f8de1669e",
+                "sha256:ba59edeaa2fc6114428f1637ffff42da1e311e29382d81b339c1817d37ec93c6",
+                "sha256:b00c1de48212e4cc9603895652c5c410df699856a2853135b3967591e4beebc2",
+                "sha256:9bf40443012702a1d2070043cb6291650a0841ece432556f784f004937f0f32c",
+                "sha256:29872e92839765e546828bb7754a68c418d927cd064fd4708fab9fe9c8bb116b"
             ],
-            "version": "==1.1.0"
+            "version": "==1.1.1"
         },
         "packaging": {
             "hashes": [
@@ -324,10 +324,10 @@
         },
         "pluggy": {
             "hashes": [
-                "sha256:980710797ff6a041e9a73a5787804f848996ecaa6f8a1b1e08224a5894f2074a",
-                "sha256:8ddc32f03971bfdf900a81961a48ccf2fb677cf7715108f85295c67405798616"
+                "sha256:84d306a647cc805219916e62aab89caa97a33a1dd8c342e87a37f91073cd4746",
+                "sha256:19ecf9ce9db2fce065a7a0586e07cfb4ac8614fe96edf628a264b1c70116cf8f"
             ],
-            "version": "==0.8.1"
+            "version": "==0.9.0"
         },
         "port-for": {
             "hashes": [
@@ -337,10 +337,10 @@
         },
         "py": {
             "hashes": [
-                "sha256:e76826342cefe3c3d5f7e8ee4316b80d1dd8a300781612ddbc765c17ba25a6c6",
-                "sha256:bf92637198836372b520efcba9e020c330123be8ce527e535d185ed4b6f45694"
+                "sha256:64f65755aee5b381cea27766a3a147c3f15b9b6b9ac88676de66ba2ae36793fa",
+                "sha256:dc639b046a6e2cff5bbe40194ad65936d6ba360b52b3c3fe1d08a82dd50b5e53"
             ],
-            "version": "==1.7.0"
+            "version": "==1.8.0"
         },
         "pygments": {
             "hashes": [
@@ -483,10 +483,10 @@
         },
         "virtualenv": {
             "hashes": [
-                "sha256:8b9abfc51c38b70f61634bf265e5beacf6fae11fc25d355d1871f49b8e45f0db",
-                "sha256:cceab52aa7d4df1e1871a70236eb2b89fcfe29b6b43510d9738689787c513261"
+                "sha256:dffd40d19ab0168c02cf936de59590a3c0f2c8c4a36f363fcf3dae18728dc94e",
+                "sha256:5a3ecdfbde67a4a3b3111301c4d64a5b71cf862c8c42958d30cf3253df1f29dd"
             ],
-            "version": "==16.4.0"
+            "version": "==16.4.1"
         },
         "watchdog": {
             "hashes": [

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.9
+current_version = 0.1.10
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ test_requirements = [
 
 setup(
     name='verifone',
-    version='0.1.9',
+    version='0.1.10',
     description="Python package for Verifone",
     long_description=readme + '\n\n' + history,
     author="Jaana Sarajärvi",

--- a/tests/test_verifone.py
+++ b/tests/test_verifone.py
@@ -250,14 +250,14 @@ class TestVerifone(unittest.TestCase):
                 'i-t-1-4_bi-vat-percentage-0': '2400',
                 'i-t-1-4_bi-discount-percentage-0': 0,
             }
-            with self.assertRaises(ValueError):
-                self._verifone_client.generate_payment_link(params)
+            result = self._verifone_client.generate_payment_link(params)
+            self.assertTrue('s-f-1-30_error-message' in result)
 
     def test_013_get_payment_link_status(self):
         """ Test to get payment link status. """
         if (self._test_requests == "1"):
-            with self.assertRaises(ValueError):
-                self._verifone_client.get_payment_link_status(12345678)
+            result = self._verifone_client.get_payment_link_status(12345678)
+            self.assertTrue('s-f-1-30_error-message' in result)
 
     def test_014_reactivate_payment_link(self):
         """ Test to reactivate payment link. """
@@ -265,8 +265,8 @@ class TestVerifone(unittest.TestCase):
             current_time = datetime.now()
             timestamp = current_time.strftime('%Y-%m-%d %H:%M:%S')
 
-            with self.assertRaises(ValueError):
-                self._verifone_client.reactivate_payment_link(12345678, timestamp)
+            result = self._verifone_client.reactivate_payment_link(12345678, timestamp)
+            self.assertTrue('s-f-1-30_error-message' in result)
 
     def test_015_process_payment(self):
         """ Test to process payment """
@@ -352,8 +352,9 @@ class TestVerifone(unittest.TestCase):
                 's-f-1-30_payment-method-code': 'visa',
                 'l-f-1-20_transaction-number': '123456',
             }
-            with self.assertRaises(ValueError):
-                self._verifone_client.cancel_payment(params)
+            result = self._verifone_client.cancel_payment(params)
+            self.assertTrue('s-f-1-30_error-message' in result)
+            self.assertEqual(result['s-f-1-30_error-message'],'invalid-transaction-number')
 
     def test_020_process_supplementary(self):
         """ Test to process supplementary. """
@@ -363,8 +364,10 @@ class TestVerifone(unittest.TestCase):
                 's-f-1-30_payment-method-code': 'visa',
                 'l-f-1-20_order-gross-amount': 500,
             }
-            with self.assertRaises(ValueError):
-                self._verifone_client.process_supplementary(params)
+            result = self._verifone_client.process_supplementary(params)
+            self.assertTrue('s-f-1-30_error-message' in result)
+            self.assertEqual(result['s-f-1-30_error-message'],'invalid-transaction-number')
+
 
     def test_021_get_endpoint(self):
         """ Test for getting endpoints """
@@ -439,6 +442,45 @@ class TestVerifone(unittest.TestCase):
 
         print(response)
         self._verifone_client.verify_response(response)
+
+    def test_026_process_payment_with_error(self):
+        """ Test to process payment when error occurs. (Test system returns error if amount is in between 90-100.) """
+        if (self._test_requests == "1"):
+            params = {
+                's-f-1-30_buyer-first-name': 'Test',
+                's-f-1-30_buyer-last-name': 'Tester',
+                's-f-1-100_buyer-email-address': os.environ.get('EMAIL'),
+                's-t-1-30_buyer-phone-number': '123456789',
+                's-t-1-255_buyer-external-id': os.environ.get('EXTERNALID'),
+            }
+            response = self._verifone_client.list_saved_payment_methods(params)
+            saved_payment_id = response['l-t-1-20_payment-method-id-0']
+            self.assertIsNotNone(saved_payment_id)
+
+            params = {
+                'locale-f-2-5_payment-locale': 'fi_FI',
+                's-f-1-36_order-number': '1234',
+                'l-f-1-20_order-gross-amount': 9100,
+                's-f-1-30_buyer-first-name': "Test",
+                's-f-1-30_buyer-last-name': "Tester",
+                's-t-1-30_buyer-phone-number': 123456789,
+                's-f-1-100_buyer-email-address': os.environ.get('EMAIL'),
+                's-t-1-30_delivery-address-line-one': "Test Street 3",
+                's-t-1-30_delivery-address-city': "Tampere",
+                's-t-1-30_delivery-address-postal-code': "33210",
+                'i-t-1-3_delivery-address-country-code': 'FI',
+                's-t-1-30_bi-name-0': 'Test Product',
+                'l-t-1-20_bi-unit-gross-cost-0': 9100,
+                'i-t-1-11_bi-unit-count-0': 1,
+                'l-t-1-20_bi-gross-amount-0': 9100,
+                'l-t-1-20_bi-net-amount-0': 7339,
+                'i-t-1-4_bi-vat-percentage-0': 2400,
+                'i-t-1-4_bi-discount-percentage-0': 0,
+                's-t-1-255_buyer-external-id': os.environ.get('EXTERNALID'),
+                'l-t-1-20_saved-payment-method-id': saved_payment_id,
+            }
+            response = self._verifone_client.process_payment(params)
+            self.assertTrue('s-f-1-30_error-message' in response)
 
 
 

--- a/verifone/__init__.py
+++ b/verifone/__init__.py
@@ -4,4 +4,4 @@
 
 __author__ = """Jaana Sarajärvi"""
 __email__ = 'jaana.sarajarvi@vilkas.fi'
-__version__ = '0.1.9'
+__version__ = '0.1.10'

--- a/verifone/verifone.py
+++ b/verifone/verifone.py
@@ -666,7 +666,7 @@ class Verifone(object):
         parsed_response = self.parse_response(response.content)
 
         if 's-f-1-30_error-message' in parsed_response:
-            raise ValueError(parsed_response['s-f-1-30_error-message'])
+            return parsed_response
 
         self.verify_response(parsed_response)
 


### PR DESCRIPTION
* Modified method "send_request". It does not throw anymore error if 's-f-1-30_error-message' is returned.
* Updated Pipfile.lock.