### PR TITLE
remove pip from requirements_dev.txt

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,4 +1,3 @@
-pip==20.0.1
 bumpversion==0.5.3
 wheel==0.33.6
 watchdog==0.9.0


### PR DESCRIPTION
Doesn't really make sense to have it there.